### PR TITLE
Append script to `<head />` instead of `<body />`

### DIFF
--- a/src/ga4.js
+++ b/src/ga4.js
@@ -91,7 +91,7 @@ export class GA4 {
       if (nonce) {
         script.setAttribute("nonce", nonce);
       }
-      document.body.appendChild(script);
+      document.head.appendChild(script);
 
       window.dataLayer = window.dataLayer || [];
       window.gtag = function gtag() {


### PR DESCRIPTION
> Copy the global site tag into the <head> section of your HTML. 

Just following Google's instruction. Closes #29 