### PR TITLE
fix: prevent the invalid call of readyCallbak when it is undefined

### DIFF
--- a/src/ga4.js
+++ b/src/ga4.js
@@ -372,16 +372,18 @@ export class GA4 {
         this._isQueuing = false;
         const queues = this._queueGtag;
 
-        readyCallback({
-          get: (property) =>
-            property === "clientId"
-              ? clientId
-              : property === "trackingId"
-              ? this._currentMeasurementId
-              : property === "apiVersion"
-              ? "1"
-              : undefined,
-        });
+        if(readyCallback) {
+          readyCallback({
+            get: (property) =>
+              property === "clientId"
+                ? clientId
+                : property === "trackingId"
+                ? this._currentMeasurementId
+                : property === "apiVersion"
+                ? "1"
+                : undefined,
+          });
+        }
 
         while (queues.length) {
           const queue = queues.shift();


### PR DESCRIPTION
Sometimes readyCallbak is undefined and it is causing an error in the console. And if you are using an error tracker it is captured