### PR TITLE
make sure page title shows up on google analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@ npm i react-ga4
 import ReactGA from "react-ga4";
 
 ReactGA.initialize("your GA measurement id");
-ReactGA.send("pageview");
+
+const page = window.location.pathname + window.location.search;
+ReactGA.send({ hitType: "pageview", page, title: page });
+
 ```
 
 ## Example


### PR DESCRIPTION
If I only use `ReactGA.send("pageview");` I can't see the page views on Google analytics. I had to use `ReactGA.send({ hitType: "pageview", page, title: page });` in order to see the page views for different pages on GA. 
